### PR TITLE
Adding easyxdm to sky distribution

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function (grunt) {
         'bower_components/blockui/jquery.blockUI.js',
         'bower_components/angular-ui-select/dist/select.js',
         'bower_components/fastclick/lib/fastclick.js',
-        'bower_components/ng-file-upload/ng-file-upload.js'
+        'bower_components/ng-file-upload/ng-file-upload.js',
+        'libs/easyXDM.js'
     ];
 
     skyJs = src.concat([


### PR DESCRIPTION
OK, thought I could get this in through bower but it turns out that easyXDM is a very old library and the only place I found that includes it through bower is https://github.com/hull/easyXDM.  There is a PR to add the new version of easyXDM to this repo but it is pretty stale.  If we want to go down this route just let me know and I can update this.  

This PR is to just include the easyXDM library into the sky bundle to satisfy the dependency requirement of the help widget.
