### PR TITLE
Setting progress to false before npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
   - chmod +x update-skyux-visualtest-results.sh
   - chmod +x run-browserstack-local.sh
 
+  # https://github.com/npm/npm/issues/11283
+  - npm set progress=false
+
 # Install a few additional things outside those listed in package.json
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Interesting bug where `npm install` time can be significantly reduced by disabling progress output.  Following others to see if we see performance increase.  https://github.com/npm/npm/issues/11283
