### PR TITLE
remove unnecessary animation class manipulation for tiles #359

### DIFF
--- a/js/sky/src/tiles/test/tiles.spec.js
+++ b/js/sky/src/tiles/test/tiles.spec.js
@@ -57,7 +57,6 @@ describe('Tile', function () {
                 };
             });
         }
-
         function initializeTile($scope, tileId) {
             var el = $compile(
                 '<bb-tile bb-tile-collapsed="tileCollapsed">a</bb-tile>'

--- a/js/sky/src/tiles/tiles.js
+++ b/js/sky/src/tiles/tiles.js
@@ -63,16 +63,6 @@
                         }
 
                         scope.isCollapsed = collapsed;
-
-                        if (collapsed && !tileInitialized) {
-                            //in some cases the tile-content div is left in a partially collapsed state.
-                            //   this will ensure that the tile is styled corretly and the tile is completely collapsed
-                            $timeout(function () {
-                                var contentEl;
-                                contentEl = el.find('.bb-tile-content');
-                                contentEl.removeClass('collapsing').addClass('collapse');
-                            }, 1);
-                        }
                     }
 
                     function updateHeaderContent() {


### PR DESCRIPTION
This is line is not necessary since the ui-bootstrap upgrades handle
animation for collapse.
