### PR TITLE
Only running install commands when necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ before_install:
 
   # https://github.com/npm/npm/issues/11283
   - npm set progress=false
-
-# These are needed first since npm test calls grunt
-before_script:
   - npm install -g grunt-cli
   - npm install -g bower
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - gem install sass
 
   # Make our three scripts executable
+  - chmod +x ./scripts/install-cache.sh
   - chmod +x ./scripts/update-skyux.sh
   - chmod +x ./scripts/update-skyux-docs.sh
   - chmod +x ./scripts/update-skyux-releases.sh
@@ -32,11 +33,12 @@ before_install:
   # https://github.com/npm/npm/issues/11283
   - npm set progress=false
 
-# Install a few additional things outside those listed in package.json
-before_script:
+# Utilize the cached versions when appropriate
+install:
   - npm install -g grunt-cli
   - npm install -g bower
-  - bower install
+  - ./scripts/install-cache.sh npm
+  - ./scripts/install-cache.sh bower
 
 # We want deployment failures to fail the build
 script: npm test && ./scripts/update-skyux.sh && ./scripts/update-skyux-releases.sh && ./scripts/update-skyux-docs.sh
@@ -57,6 +59,7 @@ cache:
     - $HOME/node_modules
     - $HOME/bower_components
     - $BROWSER_STACK_BINARY_BASE_PATH
+    - $CONFIG_CACHE
 
 notifications:
   slack:
@@ -67,3 +70,4 @@ notifications:
 env:
   global:
     - BROWSER_STACK_BINARY_BASE_PATH=$HOME/browserstack-binary
+    - CONFIG_CACHE=$HOME/config-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,9 @@ branches:
 # Cache a few things
 cache:
   directories:
-    - $HOME/node_modules
-    - $HOME/bower_components
+    - node_modules
+    - bower_components
     - $BROWSER_STACK_BINARY_BASE_PATH
-    - $CONFIG_CACHE
 
 notifications:
   slack:
@@ -70,4 +69,3 @@ notifications:
 env:
   global:
     - BROWSER_STACK_BINARY_BASE_PATH=$HOME/browserstack-binary
-    - CONFIG_CACHE=$HOME/config-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,13 @@ before_install:
   # https://github.com/npm/npm/issues/11283
   - npm set progress=false
 
-# Utilize the cached versions when appropriate
-install:
+# These are needed first since npm test calls grunt
+before_script:
   - npm install -g grunt-cli
   - npm install -g bower
+
+# Utilize the cached versions when appropriate
+install:
   - ./scripts/install-cache.sh npm
   - ./scripts/install-cache.sh bower
 

--- a/scripts/install-cache.sh
+++ b/scripts/install-cache.sh
@@ -1,0 +1,29 @@
+# Even though we cache node_modules/bower_components, npm/bower install is still slow.
+# This allows us to only run npm/bower install when necessary.
+
+# Read mode passed in as first argument
+mode=$1
+
+# Verify npm or bower scenario
+case $mode in
+  npm)
+    json_file="package.json"
+    cache_dir="node_modules"
+    ;;
+  bower)
+    json_file="bower.json"
+    cache_dir="bower_components"
+    ;;
+  *)
+    echo "Unknown install mode: $mode"
+    exit 1
+    ;;
+esac
+
+# Verify cache directories exist and no difference in config files
+if [[ -d "$HOME/$cache_dir" ]] && [[ -d "$CONFIG_CACHE" ]] && cmp --silent $json_file $CONFIG_CACHE/$json_file; then
+  echo "$mode install successfully bypassed with cache."
+else
+  echo "Unable to use cache for $mode.  Beginning install now."
+  $mode install
+fi

--- a/scripts/install-cache.sh
+++ b/scripts/install-cache.sh
@@ -1,5 +1,6 @@
 # Even though we cache node_modules/bower_components, npm/bower install is still slow.
 # This allows us to only run npm/bower install when necessary.
+# We stash the json file back in the cached directory.
 
 # Read mode passed in as first argument
 mode=$1
@@ -8,11 +9,11 @@ mode=$1
 case $mode in
   npm)
     json_file="package.json"
-    cache_dir="node_modules"
+    cache_dir="$TRAVIS_BUILD_DIR/node_modules"
     ;;
   bower)
     json_file="bower.json"
-    cache_dir="bower_components"
+    cache_dir="$TRAVIS_BUILD_DIR/bower_components"
     ;;
   *)
     echo "Unknown install mode: $mode"
@@ -21,11 +22,12 @@ case $mode in
 esac
 
 # Verify cache directories exist and no difference in config files
-if [[ -d "$HOME/$cache_dir" ]] && [[ -d "$CONFIG_CACHE" ]] && cmp --silent $json_file $CONFIG_CACHE/$json_file; then
+if [[ -d "$cache_dir" ]] && cmp --silent $TRAVIS_BUILD_DIR/$json_file /$cache_dir/$json_file; then
   echo "$mode install successfully bypassed with cache."
 else
   echo "Unable to use cache for $mode.  Beginning install now."
   $mode install
+
   echo "Caching $json_file for future builds."
-  cp $json_file $CONFIG_CACHE
+  cp $TRAVIS_BUILD_DIR/$json_file $cache_dir/$json_file
 fi

--- a/scripts/install-cache.sh
+++ b/scripts/install-cache.sh
@@ -26,4 +26,6 @@ if [[ -d "$HOME/$cache_dir" ]] && [[ -d "$CONFIG_CACHE" ]] && cmp --silent $json
 else
   echo "Unable to use cache for $mode.  Beginning install now."
   $mode install
+  echo "Caching $json_file for future builds."
+  cp $json_file $CONFIG_CACHE
 fi


### PR DESCRIPTION
After a few commits of trial-and-error, I finally realized I was we are currently not caching the `node_modules/` and `bower_components/` folders correctly.  Correcting that, in conjunction with overwriting the `npm install` task, will reduce build times by around 2 minutes.
