### PR TITLE
Testing speed with just correcting cached folder locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ branches:
 # Cache a few things
 cache:
   directories:
-    - $HOME/node_modules
-    - $HOME/bower_components
+    - node_modules
+    - bower_components
     - $BROWSER_STACK_BINARY_BASE_PATH
 
 notifications:


### PR DESCRIPTION
Related to #386, but testing by only specifying the correct folders to cache, as opposed to not running `npm install` or `bower install` at all.
