### PR TITLE
update tabsref to use $state.includes instead of $state.is

### DIFF
--- a/js/sky/src/tabsref/tabsref.js
+++ b/js/sky/src/tabsref/tabsref.js
@@ -12,7 +12,7 @@
                         stateChangeDeregistration;
 
                     function checkCurrentState() {
-                        if ($state.is(sref)) {
+                        if ($state.includes(sref)) {
                             tabsetCtrl.select(el.isolateScope().index);
                         }
                     }
@@ -29,7 +29,7 @@
                         scope.$watch(function () {
                             return tabsetCtrl.active;
                         }, function (newValue) {
-                            if (newValue === el.isolateScope().index && !$state.is(sref)) {
+                            if (newValue === el.isolateScope().index && !$state.includes(sref)) {
                                 // JPB - Delay calling state.go because the state change will fail
                                 // if it is triggered while in the middle of processing of another state change.
                                 // This can happen if you browse to the page without specifying the state of a particular tab

--- a/js/sky/src/tabsref/test/tabsref.spec.js
+++ b/js/sky/src/tabsref/test/tabsref.spec.js
@@ -24,7 +24,8 @@ describe('Tab Sref directive', function () {
 
         $state = {
             go: angular.noop,
-            is: angular.noop
+            is: angular.noop,
+            includes: angular.noop
         };
 
         $provide.value('$state', $state);

--- a/js/sky/src/tabsref/test/tabsref.spec.js
+++ b/js/sky/src/tabsref/test/tabsref.spec.js
@@ -53,7 +53,7 @@ describe('Tab Sref directive', function () {
                 tabSelectCalled,
                 $scope = $rootScope.$new();
 
-            $state.is = function (sref) {
+            $state.includes = function (sref) {
                 return sref === 'tabstate.b';
             };
 
@@ -85,7 +85,7 @@ describe('Tab Sref directive', function () {
                 stateGoCalled = true;
             };
 
-            $state.is = function (sref) {
+            $state.includes = function (sref) {
                 return sref === "tabstate.a";
             };
 
@@ -146,7 +146,7 @@ describe('Tab Sref directive', function () {
                 tabSelectCalled,
                 $scope = $rootScope.$new();
 
-            $state.is = function (sref) {
+            $state.includes = function (sref) {
                 return sref === 'tabstate.b';
             };
 
@@ -183,7 +183,7 @@ describe('Tab Sref directive', function () {
                 stateGoCalled = true;
             };
 
-            $state.is = function (sref) {
+            $state.includes = function (sref) {
                 return sref === "tabstate.a";
             };
 


### PR DESCRIPTION
This correctly handles child states inside of tabs
