### PR TITLE
Latest Stache version, removed prism reference, fixed layout

### DIFF
--- a/demo/content/index.html
+++ b/demo/content/index.html
@@ -1,6 +1,6 @@
 ---
 order: 1
-layout: layout-base
+layout: layout-container
 ---
 
 <h1>Documentation</h1>

--- a/demo/includes/partial-sky-css.hbs
+++ b/demo/includes/partial-sky-css.hbs
@@ -1,8 +1,2 @@
-<!-- build:css {{ assets }}css/app.min.css -->
 <link rel="stylesheet" href="{{ assets }}css/app.css">
-{{# if stache.config.prism }}
-  <link rel="stylesheet" href="{{ assets }}css/prism.css">
-{{/ if }}
-<!-- endbuild -->
-
 <link rel="stylesheet" href="/bin/css/sky-bundle.css">

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "angular-mocks": "1.5.3",
     "assemble-yaml": "0.2.1",
     "axe-core": "1.1.1",
-    "blackbaud-stache": "0.7.23",
+    "blackbaud-stache": "0.7.25",
     "browserstacktunnel-wrapper": "1.4.2",
     "codecov": "1.0.1",
     "dotenv": "2.0.0",


### PR DESCRIPTION
- Pulling in the latest version of Stache (removed color overrides).
- Removed old overrides where we referenced prism, which caused 404 errors when serving demo (included in Stache automatically now).
- Set landing page layout to container (looks better).
