### PR TITLE
improve accessibility for tabset (#661)

### DIFF
--- a/js/sky/locales/resources_en_US.json
+++ b/js/sky/locales/resources_en_US.json
@@ -566,5 +566,13 @@
     "reorder_top": {
       "_description": "Text displayed to indicate that a row can be pushed to the top of the list",
       "message": "Top"
+    },
+    "tab_add": {
+      "_description": "Screen reader text for the add button on a tabset",
+      "message": "Add tab"
+    },
+    "tab_open": {
+        "_description": "Screen reader text for the open button on a tabset",
+        "message": "Open"
     }
 }

--- a/js/sky/src/tabset/tabset.js
+++ b/js/sky/src/tabset/tabset.js
@@ -312,7 +312,7 @@
 
     bbTabHeadingXs.$inject = ['$compile', '$templateCache'];
 
-    angular.module('sky.tabset', ['ui.bootstrap.tabs', 'sky.mediabreakpoints'])
+    angular.module('sky.tabset', ['ui.bootstrap.tabs', 'sky.mediabreakpoints', 'sky.resources'])
         .directive('uibTabset', tabset)
         .directive('bbTabsetCollapsible', bbTabsetCollapsible)
         .directive('bbTabCollapseHeader', bbTabCollapseHeader)

--- a/js/sky/src/tabset/test/tabset.spec.js
+++ b/js/sky/src/tabset/test/tabset.spec.js
@@ -9,7 +9,8 @@ describe('Tabset module', function () {
         dynamicTabsHtml,
         $scope,
         bbMediaBreakpoints,
-        $timeout;
+        $timeout,
+        bbResources;
 
     beforeEach(module(
         'ngMock',
@@ -19,12 +20,13 @@ describe('Tabset module', function () {
         'uib/template/tabs/tab.html'
     ));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$document_, _bbMediaBreakpoints_, _$timeout_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$document_, _bbMediaBreakpoints_, _$timeout_, _bbResources_) {
         $compile = _$compile_;
         $scope = _$rootScope_.$new();
         $document = _$document_;
         bbMediaBreakpoints = _bbMediaBreakpoints_;
         $timeout = _$timeout_;
+        bbResources = _bbResources_;
 
         dynamicTabsHtml = '<uib-tabset bb-tabset-add="addTab()" bb-tabset-open="openTab()">' +
                 '<uib-tab>' +
@@ -210,6 +212,17 @@ describe('Tabset module', function () {
             getLargeScreenAddButton(el).click();
             $scope.$digest();
             expect(tabAdded).toBe(true);
+        });
+
+        it('should allows the screen reader text for the add tab button to be localizable', function () {
+            var el;
+
+            bbResources.tab_add = '__test__add';
+
+            el = $compile(dynamicTabsHtml)($scope);
+            $scope.$digest();
+
+            expect(el.find('.bb-tab-button-add').attr('aria-label')).toContain(bbResources.tab_add);
         });
     });
 

--- a/js/sky/templates/tabset/addbutton.html
+++ b/js/sky/templates/tabset/addbutton.html
@@ -1,3 +1,3 @@
-<button ng-click="bbTabAdd()" type="button" class="bb-tab-button-wrap btn bb-tab-button-add bb-btn-secondary">
+<button ng-click="bbTabAdd()" type="button" class="bb-tab-button-wrap btn bb-tab-button-add bb-btn-secondary" aria-label="{{'tab_add' | bbResources}}">
   <span class="btn bb-btn-secondary"><i class="fa fa-lg fa-plus-circle"></i></span>
 </button>

--- a/js/sky/templates/tabset/openbutton.html
+++ b/js/sky/templates/tabset/openbutton.html
@@ -1,3 +1,3 @@
-<button ng-click="bbTabOpen()" type="button" class="bb-tab-button-wrap bb-tab-button-open btn bb-btn-secondary">
+<button ng-click="bbTabOpen()" type="button" class="bb-tab-button-wrap bb-tab-button-open btn bb-btn-secondary" aria-label="{{'tab_open' | bbResources}}">
   <span class="btn bb-btn-secondary"><i class="fa fa-lg fa-folder-open-o"></i></span>
 </button>

--- a/webdrivertest/test/common.js
+++ b/webdrivertest/test/common.js
@@ -24,9 +24,10 @@
     function checkAccessibility(options) {
         options.browserResult.executeAsync(function (done) {
             axe.a11yCheck(
-                document, 
+                document,
                 {
                     "rules": {
+                        "bypass": { enabled: false },
                         "color-contrast": { enabled: false }
                     }
                 },

--- a/webdrivertest/test/tabset/tabset.visual.js
+++ b/webdrivertest/test/tabset/tabset.visual.js
@@ -15,6 +15,7 @@ describe('tabset', function () {
             prefix: common.getPrefix(browser),
             screenshotName: 'tabset',
             selector: '#screenshot-tabset-all',
+            checkAccessibility: true,
             done: done,
             screenWidth: [480, 1280]
         });


### PR DESCRIPTION
Summary of changes made:
- added `aria-label` attributes to `addbutton.html` and `openbutton.html` templates
- added `sky.resources` module to `sky.tabset` dependencies for localization of text
- added default English text for screen readers in `js/sky/locales/resources_en_US.json`
- added unit test to `js/sky/src/tabset/test/tabset.spec.js` to check for presence of localized ARIA attributes
- enabled accessibility checking
- disabled [`bypass`](https://github.com/dequelabs/axe-core/blob/master/lib/rules/bypass.json) rule for accessibility tests
