### PR TITLE
Replace loadMore() jqgrid addRowData() call with addJsonData() 

### DIFF
--- a/js/sky/src/grids/grids.js
+++ b/js/sky/src/grids/grids.js
@@ -1294,7 +1294,7 @@
                                     loadMorePromise = deferred.promise;
 
                                 loadMorePromise.then(function (moreRows) {
-                                    tableEl.addRowData('', moreRows);
+                                    tableDomEl.addJSONData(moreRows);
                                     $scope.options.data = $scope.options.data.concat(moreRows);
                                     setUpFancyCheckCell();
                                     doNotResetRows = true;


### PR DESCRIPTION
Following up on the work from https://github.com/blackbaud/skyux/issues/225

Replace `loadMore()` jqgrid `addRowData()` with `addJsonData()` since addRowData requires a [specific syntax](http://www.trirand.com/jqgridwiki/doku.php?id=wiki%3amethods) that does not work with the afterInsertRow callback where the rowdata is accessed by array syntax but does not work with JSON dot notation. `AddRowData` works until you have you nested objects. 

Differences in rowdata format on the [afterInsertRow callback](https://github.com/blackbaud/skyux/blob/14457ffa5297368f129b4043b24941079e14cbf6/js/sky/src/grids/grids.js#L736)
addJsonData() =
![screen shot 2016-07-11 at 9 59 54 am](https://cloud.githubusercontent.com/assets/11817620/16734572/0b95aec8-4754-11e6-9040-fdf5f0e6f013.png)

vs 

addRowData() = 
![screen shot 2016-07-11 at 9 59 29 am](https://cloud.githubusercontent.com/assets/11817620/16734628/38c7b440-4754-11e6-95db-22e63aa36fc0.png)

The `addJsonData` formats the row data where the object key = the column name so the array like access of the object works until you attempt to `addRowData` where you actually need the object traversed but fails on the array syntax.
