### PR TITLE
bb-phone-field: Removing ng-model update

### DIFF
--- a/js/sky/src/phonefield/phonefield.directive.js
+++ b/js/sky/src/phonefield/phonefield.directive.js
@@ -40,16 +40,10 @@
                 return getFormattedNumber();
             });
             ngModel.$formatters.unshift(function (value) {
-                var formattedNumber;
                 if (value) {
                     input.intlTelInput('setNumber', value);
-                    if (input.intlTelInput('isValidNumber')) {
-                        formattedNumber = getFormattedNumber();
-                        ngModel.$setViewValue(formattedNumber);
-                        input.val(formattedNumber);
-                    }
                 }
-                return formattedNumber;
+                return getFormattedNumber();
             });
             // tie ng-model's format validation to the plugin's validator
             ngModel.$validators.bbPhoneFormat = function (modelValue) {

--- a/js/sky/src/phonefield/phonefield.directive.js
+++ b/js/sky/src/phonefield/phonefield.directive.js
@@ -40,10 +40,16 @@
                 return getFormattedNumber();
             });
             ngModel.$formatters.unshift(function (value) {
+                var formattedNumber;
                 if (value) {
                     input.intlTelInput('setNumber', value);
+                    formattedNumber = getFormattedNumber();
+                    if (input.intlTelInput('isValidNumber')) {
+                        ngModel.$setViewValue(formattedNumber);
+                    }
+                    input.val(formattedNumber);
                 }
-                return getFormattedNumber();
+                return formattedNumber;
             });
             // tie ng-model's format validation to the plugin's validator
             ngModel.$validators.bbPhoneFormat = function (modelValue) {

--- a/js/sky/src/phonefield/test/phonefield.spec.js
+++ b/js/sky/src/phonefield/test/phonefield.spec.js
@@ -379,4 +379,26 @@ describe('Phone field directive', function () {
         el.remove();
     });
 
+    it('should show whatever value is in the ng-model in the textbox no matter its validity as a phone number.', function () {
+        //** arrange **
+        var el,
+            $scope = $rootScope.$new(),
+            invalid = 'invalid_number';
+        $scope.phoneFieldConfig = {
+            countryIso2: nationalCountryData.iso2
+        };
+
+        // ** act ***
+        $scope.phoneNumber = invalid;
+        el = compileDirective($scope);
+        el.appendTo(document.body);
+        $scope.$digest();
+
+        // ** assert **
+        expect(directiveElements.input(el).val()).toBe(invalid);
+
+        // ** clean up **
+        el.remove();
+    });
+
 });

--- a/js/sky/src/phonefield/test/phonefield.spec.js
+++ b/js/sky/src/phonefield/test/phonefield.spec.js
@@ -358,25 +358,4 @@ describe('Phone field directive', function () {
         el.remove();
     });
 
-    it('should format the ng-model value if it is not formatted but is a valid phone number upon its intial load.', function () {
-        // ** arrange **
-        var el,
-            $scope = $rootScope.$new();
-        $scope.phoneFieldConfig = {
-            countryIso2: nationalCountryData.iso2
-        };
-
-        // ** act ***
-        $scope.phoneNumber = nationalCountryData.unformattedTestNumber;
-        el = compileDirective($scope);
-        el.appendTo(document.body);
-        $scope.$digest();
-
-        // ** assert **
-        expect($scope.phoneNumber).toBe(nationalCountryData.formattedTestNumber);
-
-        // ** clean up **
-        el.remove();
-    });
-
 });

--- a/js/sky/src/phonefield/test/phonefield.spec.js
+++ b/js/sky/src/phonefield/test/phonefield.spec.js
@@ -358,4 +358,25 @@ describe('Phone field directive', function () {
         el.remove();
     });
 
+    it('should format the ng-model value if it is not formatted but is a valid phone number upon its intial load.', function () {
+        //** arrange **
+        var el,
+            $scope = $rootScope.$new();
+        $scope.phoneFieldConfig = {
+            countryIso2: nationalCountryData.iso2
+        };
+
+        // ** act ***
+        $scope.phoneNumber = nationalCountryData.unformattedTestNumber;
+        el = compileDirective($scope);
+        el.appendTo(document.body);
+        $scope.$digest();
+
+        // ** assert **
+        expect($scope.phoneNumber).toBe(nationalCountryData.formattedTestNumber);
+
+        // ** clean up **
+        el.remove();
+    });
+
 });


### PR DESCRIPTION
Originally, when the ng-model for the bb-phone-field directive is loaded with an invalid number, it is automatically formatted if valid or blanked out of the textbox if invalid.

Because we want any and all text to be loaded to the bb-phone-field directive, we are removing this update. This way, "numbers" that were already invalid or unformatted will stay that way until they are intentionally edited or saved. Upon save, they will be validated and formatted accordingly, not before.
