### PR TITLE
#861 - converting help-button to use an actual button

### DIFF
--- a/js/sky/src/helpbutton/docs/demo.html
+++ b/js/sky/src/helpbutton/docs/demo.html
@@ -1,2 +1,2 @@
 <div style="float: left; margin-right: 5px">This help icon opens a help key that is not based on page context:</div>
-<div bb-help-button bb-help-key="bb-security-users.html"></div>
+<button type="button" bb-help-button bb-help-key="bb-security-users.html">Help</button>

--- a/js/sky/src/helpbutton/helpbutton.js
+++ b/js/sky/src/helpbutton/helpbutton.js
@@ -18,6 +18,7 @@
                 var oldHelpKeyOverride;
 
                 el.addClass('bb-helpbutton fa fa-question-circle close');
+                el.contents().wrap('<span class="bb-invisible"></span>');
 
                 if (attrs.bbSetHelpKeyOverride && attrs.bbSetHelpKeyOverride.toLowerCase() === 'true') {
                     oldHelpKeyOverride = $state.current.helpKeyOverride;

--- a/js/sky/src/helpbutton/test/helpbutton.spec.js
+++ b/js/sky/src/helpbutton/test/helpbutton.spec.js
@@ -43,7 +43,7 @@ describe('Helpbutton directive', function () {
     }));
 
     it('adds the correct classes', function () {
-        var el = angular.element('<div bb-help-button bb-help-key="bb-security-users.html"></div>');
+        var el = angular.element('<button type="button" bb-help-button bb-help-key="bb-security-users.html">Help</button>');
 
         $compile(el)($scope);
 
@@ -54,7 +54,7 @@ describe('Helpbutton directive', function () {
     });
 
     it('handles true override keys', function () {
-        var el = angular.element('<div bb-help-button bb-help-key="bb-security-users.html" bb-set-help-key-override="true"></div>'),
+        var el = angular.element('<button type="button" bb-help-button bb-help-key="bb-security-users.html" bb-set-help-key-override="true">Help</button>'),
             removeEvent;
 
         $compile(el)($scope);
@@ -71,7 +71,7 @@ describe('Helpbutton directive', function () {
     });
 
     it('opens the help widget on click', function () {
-        var el = angular.element('<div bb-help-button bb-help-key="bb-security-users.html"></div>');
+        var el = angular.element('<button type="button" bb-help-button bb-help-key="bb-security-users.html">Help</button>');
 
         $compile(el)($scope);
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -49,3 +49,16 @@ Semantic font class styles are based on existing styling of analogous components
 .bb-field-label {
     @include bb-field-label();
 }
+
+/* Accessibly hide content - invisible to the screen, visible to screenreaders and other assistive tech. */
+.bb-invisible {
+    border: 0; 
+    clip: rect(0 0 0 0); 
+    height: 1px; 
+    margin: -1px; 
+    overflow: hidden; 
+    padding: 0; 
+    position: absolute; 
+    width: 1px;
+    pointer-events: none;
+}


### PR DESCRIPTION
Updated tests and docs to match. Also, adding a `bb-invisible` helper class for visually-hidden but accessible text. (This is a really useful utility class and I couldn't find an equivalent in the codebase already; if there is one, let me know.)

Note - I have the script adding that class inside the button, to make writing the markup simpler; this does occasionally cause the 'Help' text to appear for a second before the js/css kicks in. If this is a problem, we could make the hiding span part of the demo markup instead.
# hacktoberfest
