### PR TITLE
Wolverine Bug 691079: Ensuring a +1-only Dial Code where Necessary

### DIFF
--- a/js/sky/src/phonefield/phonefield.directive.js
+++ b/js/sky/src/phonefield/phonefield.directive.js
@@ -27,6 +27,14 @@
                     if (selectedCountryData.iso2 && phoneField.props.countryIso2.toLowerCase() === selectedCountryData.iso2.toLowerCase()) {
                         return formattedNumber;
                     } else if (selectedCountryData && formattedNumber.indexOf('+') < 0) {
+                        // Any country with a dial code that starts with 1
+                        // is so small that its dial code matches its area code.
+                        // So, its dial code should just be 1 (check Google) because the area code includes the dial code.
+                        // Example countries: Bahamas, Cayman Islands, Barbados.
+                        if (selectedCountryData.dialCode.toString()[0] === '1') {
+                            selectedCountryData.dialCode = 1;
+                        }
+
                         return '+' + selectedCountryData.dialCode + ' ' + formattedNumber;
                     }
                 }

--- a/js/sky/src/phonefield/phonefield.directive.js
+++ b/js/sky/src/phonefield/phonefield.directive.js
@@ -29,7 +29,7 @@
                     } else if (selectedCountryData && formattedNumber.indexOf('+') < 0) {
                         // Any country with a dial code that starts with 1
                         // is so small that its dial code matches its area code.
-                        // So, its dial code should just be 1 (check Google) because the area code includes the dial code.
+                        // So, its dial code should just be 1 because the area code includes the dial code.
                         // Example countries: Bahamas, Cayman Islands, Barbados.
                         if (selectedCountryData.dialCode.toString()[0] === '1') {
                             selectedCountryData.dialCode = 1;

--- a/js/sky/src/phonefield/test/phonefield.spec.js
+++ b/js/sky/src/phonefield/test/phonefield.spec.js
@@ -401,7 +401,7 @@ describe('Phone field directive', function () {
         el.remove();
     });
 
-    it('should not add the full dial code, just "+1", to a phone number for a country whose area code is its dial code (such as Cayman Islands and Bahamas).', function () {
+    it('should format the phone number of a country that uses its area code as its dial code with a +1 dial code (such as Cayman Islands and Bahamas).', function () {
         // ** arrange **
         var el,
             $scope = $rootScope.$new();

--- a/js/sky/src/phonefield/test/phonefield.spec.js
+++ b/js/sky/src/phonefield/test/phonefield.spec.js
@@ -401,4 +401,26 @@ describe('Phone field directive', function () {
         el.remove();
     });
 
+    it('should not add the full dial code, just "+1", to a phone number for a country whose area code is its dial code (such as Cayman Islands and Bahamas).', function () {
+        // ** arrange **
+        var el,
+            $scope = $rootScope.$new();
+        $scope.phoneFieldConfig = {
+            countryIso2: nationalCountryData.iso2
+        };
+        el = compileDirective($scope);
+        el.appendTo(document.body);
+        $scope.$digest();
+
+        // ** act **
+        setCountry(el, 'bs'); // 'bs' is Bahamas iso 2
+        setNumber(el, '2423591234');
+
+        // ** assert **
+        expect($scope.phoneNumber).toBe('+1 (242) 359-1234');
+
+        // ** clean up **
+        el.remove();
+    });
+
 });


### PR DESCRIPTION
Certain smaller countries, such as Bahamas and Cayman Islands, use their area codes as their dial code. Their official dial code according to Google (and the world) is +1. 

However, the intl-tel-input plug-in lists their dial codes as "1<area code>" or "1###" (1345 for Cayman Islands).

This request ensures that country dial codes that start with a "1###" come out as "1."

Before fix, 3453231234 for a Cayman Islands phone number resulted in: +1 345 (345) 323-1234.
After fix, 3451234567 for Cayman Islands phone number results in: +1 (345) 323-1234.