### PR TITLE
Ensure that inline display: block is overriden in the case of multiple full page modals

### DIFF
--- a/scss/_modals.scss
+++ b/scss/_modals.scss
@@ -144,7 +144,7 @@
 }
 
 .bb-modal-fullpage+.bb-modal-fullpage {
-    display: none;
+    display: none !important; /* important is necessary here because an inline style of display: block; is applied to this element. */
 }
 
 .bb-modal-open-fullpage {


### PR DESCRIPTION
#965