### PR TITLE
bb-search responsiveness optional

### DIFF
--- a/js/sky/src/search/docs/demo.md
+++ b/js/sky/src/search/docs/demo.md
@@ -14,6 +14,7 @@ The search component creates a mobile-responsive input control for users to ente
     - `searchText` &mdash; New search text in the search input.
   - `bb-search-text` &mdash; *(Optional.)* Specifies search text that users can supply to the seach component.
   - `bb-search-placeholder` &mdash; *(Optional.)* Specifies placeholder text to display in the search input. If you include this attribute but do not specify a value, then the search input displays the default placeholder text "Find in this list."
+  - `bb-search-mobile-response-enabled` &mdash; *(Optional.)* `true` if the component should hide the text input and display a search button on mobile devices, `false` if otherwise. *(Default: `true`)*
 - `bb-search-container` &mdash; Makes the `bb-search-input` component responsive on small screens. You include this directive as an attribute with no value on the container for the `bb-search-input` component.
 
 ### Search events ###

--- a/js/sky/src/search/search.input.component.js
+++ b/js/sky/src/search/search.input.component.js
@@ -7,13 +7,13 @@
         var ctrl = this,
             animationSpeed = 150,
             animationEase = 'linear';
-        
+
         function applySearchText(searchText) {
             //select input
             var searchEl = $element.find('.bb-search-input');
 
             ctrl.showClear = searchText && searchText !== '';
-            
+
             /*istanbul ignore else */
             /* sanity check */
             if (angular.isFunction(searchEl.select) && searchEl.length > 0 && searchText) {
@@ -22,7 +22,7 @@
 
             //search callback
             ctrl.bbOnSearch({searchText: searchText});
-            
+
         }
 
         function searchTextChanged(searchText) {
@@ -37,12 +37,12 @@
 
         function clearSearchText() {
             ctrl.bbSearchText = '';
-            
+
             setInputFocus();
 
             ctrl.showClear = false;
             ctrl.bbOnSearch({searchText: ctrl.bbSearchText});
-            
+
         }
 
         function mediaBreakpointCallback(breakpoint) {
@@ -79,11 +79,11 @@
             var openEl,
                 offset,
                 buttonWidth;
-            
+
             openEl = findOpenEl();
             offset = $element.position();
             buttonWidth = openEl.outerWidth();
-            
+
             return offset.left + buttonWidth;
         }
 
@@ -108,7 +108,7 @@
 
         function toggleInputShown(isVisible) {
             var inputContainerEl = findInputContainerEl(),
-                inputHiddenClass = 'bb-search-input-container-hidden'; 
+                inputHiddenClass = 'bb-search-input-container-hidden';
 
             if (isVisible) {
                 inputContainerEl.removeClass(inputHiddenClass);
@@ -140,29 +140,29 @@
 
             var inputContainerEl,
                 expectedWidth = getExpectedInputWidth();
-                
-            inputContainerEl = findInputContainerEl();   
+
+            inputContainerEl = findInputContainerEl();
 
             toggleMobileInputVisible(ctrl.currentBreakpoint && ctrl.currentBreakpoint.xs);
-            
+
             setupInputAnimation(inputContainerEl, expectedWidth);
             toggleDismissShown(true);
             ctrl.openButtonShown = false;
-            
+
             inputContainerEl.animate(
                 {
                     width: '100%',
                     opacity: 1
-                }, 
+                },
                 animationSpeed,
                 animationEase
             );
-            
+
             //Do not focus input on mediabreakpoint change, only on actual interaction
             if (focusInput) {
                 setInputFocus();
             }
-            
+
         }
 
         function dismissSearchInput() {
@@ -240,7 +240,7 @@
         }
 
         function initSearch() {
-            
+
             if (ctrl.bbSearchText) {
                 searchTextBindingChanged();
             }
@@ -259,11 +259,13 @@
             bbMediaBreakpoints.unregister(mediaBreakpointCallback);
         }
 
-        bbMediaBreakpoints.register(mediaBreakpointCallback);
+        if (angular.isUndefined(ctrl.bbSearchMobileResponseEnabled) || ctrl.bbSearchMobileResponseEnabled) {
+            bbMediaBreakpoints.register(mediaBreakpointCallback);
+            ctrl.$onDestroy = destroySearch;
+        }
 
         ctrl.$onInit = initSearch;
         ctrl.$onChanges = bindingChanges;
-        ctrl.$onDestroy = destroySearch;
 
         ctrl.applySearchText = applySearchText;
         ctrl.searchTextChanged = searchTextChanged;
@@ -283,7 +285,8 @@
                 bbOnSearch: '&?',
                 bbOnSearchTextChanged: '&?',
                 bbSearchText: '<?',
-                bbSearchPlaceholder: '<?'
+                bbSearchPlaceholder: '<?',
+                bbSearchMobileResponseEnabled: '<?'
             }
         });
 })();

--- a/js/sky/src/search/test/search.input.component.spec.js
+++ b/js/sky/src/search/test/search.input.component.spec.js
@@ -69,7 +69,7 @@
         }
 
         function findOpenButtonWrapper(el) {
-            return el.find('.bb-search-open-wrapper'); 
+            return el.find('.bb-search-open-wrapper');
         }
 
         function findInputContainerEl(el) {
@@ -85,7 +85,7 @@
             e.keyCode = 13;
             inputEl.trigger(e);
             $scope.$digest();
-                
+
         }
 
         function changeInput(el, val) {
@@ -108,7 +108,7 @@
                 expect(inputContainerEl).toHaveClass('bb-search-input-container-hidden');
                 expect(dismissEl).not.toBeVisible();
             }
-            
+
         }
 
         function verifyLargeScreenDismissable(openButtonEl, inputContainerEl, dismissEl, componentContainerEl) {
@@ -122,7 +122,7 @@
             var actualSearchText,
                 searchEl,
                 searchButtonEl;
-            
+
             $scope.searchCtrl = {
                 applySearchText: function (searchText) {
                     actualSearchText = searchText;
@@ -151,7 +151,7 @@
         it('can change the search text in the input using bb-search-text binding', function () {
             var inputEl,
                 searchEl;
-            
+
             $scope.searchCtrl = {
                 searchText: 'myText'
             };
@@ -177,7 +177,7 @@
         it('can call a change function when the user types in the input', function () {
             var newText,
                 searchEl;
-            
+
             $scope.searchCtrl = {
                 searchChanged: function (searchText) {
                     newText = searchText;
@@ -209,7 +209,7 @@
                 openButtonWrapperEl,
                 dismissEl,
                 containerEl;
-            
+
             spyOn(bbMediaBreakpoints, 'register').and.callFake(function (callback) {
                 searchCallback = callback;
             });
@@ -230,7 +230,7 @@
 
             openButtonEl.click();
             $scope.$digest();
-            
+
             verifySmallScreenDismissable(openButtonWrapperEl, inputContainerEl, dismissEl, containerEl, true);
             expect(inputEl).toBeFocused();
 
@@ -248,10 +248,10 @@
 
             searchCallback({xs: true});
             $scope.$digest();
-            
+
 
             verifySmallScreenDismissable(openButtonWrapperEl, inputContainerEl, dismissEl, containerEl, false);
-            
+
             searchEl.remove();
 
         });
@@ -284,13 +284,46 @@
 
         });
 
+        it('does not register the mobile-dismiss-input callback is bb-search-mobile-response-enabled is false', function () {
+            var searchEl,
+                inputEl,
+                inputContainerEl,
+                openButtonWrapperEl,
+                dismissEl,
+                containerEl,
+                nonDismissableHtml = '<bb-search-input bb-search-mobile-response-enabled="false"></bb-search-input>';
+
+            spyOn(bbMediaBreakpoints, 'register');
+
+            searchEl = initSearch(nonDismissableHtml);
+            $scope.$digest();
+
+            inputEl = findSearchInput(searchEl);
+            dismissEl = findDismissButton(searchEl);
+            containerEl = findContainerEl(searchEl);
+            inputContainerEl = findInputContainerEl(searchEl);
+            openButtonWrapperEl = findOpenButtonWrapper(searchEl);
+
+            expect(bbMediaBreakpoints.register).not.toHaveBeenCalled();
+
+            $scope.currentBreakpoint = { xs: true };
+            $scope.$digest();
+
+            verifyLargeScreenDismissable(openButtonWrapperEl, inputContainerEl, dismissEl, containerEl);
+
+            $scope.currentBreakpoint = { xs: false };
+            $scope.$digest();
+
+            verifyLargeScreenDismissable(openButtonWrapperEl, inputContainerEl, dismissEl, containerEl);
+        });
+
         it('can clear search text after it is applied using the clear search button', function () {
             var actualSearchText,
                 searchEl,
                 searchButtonEl,
                 inputEl,
                 clearButtonEl;
-            
+
             $scope.searchCtrl = {
                 applySearchText: function (searchText) {
                     actualSearchText = searchText;
@@ -308,7 +341,7 @@
 
             searchButtonEl.click();
             $scope.$digest();
-            
+
             expect(clearButtonEl).toBeVisible();
             expect(searchButtonEl).toBeVisible();
 
@@ -340,7 +373,7 @@
                 clearButtonEl,
                 inputContainerEl,
                 searchCallback;
-            
+
             $scope.searchCtrl = {
                 searchText: 'myText'
             };
@@ -380,7 +413,7 @@
 
             $scope.searchCtrl.searchText = '';
             $scope.$digest();
-            
+
             verifySmallScreenDismissable(openButtonWrapperEl, inputContainerEl, dismissEl, containerEl,  true);
             expect(clearButtonEl).not.toBeVisible();
             expect(searchButtonEl).toBeVisible();
@@ -434,7 +467,7 @@
             it('has no placeholder text when bbSearchPlaceholder is undefined', function () {
                 var searchEl,
                     inputEl;
-                
+
                 searchEl = initSearch(searchHtml);
 
                 inputEl = findSearchInput(searchEl);
@@ -451,7 +484,7 @@
                     'bb-search-placeholder ' +
                     'bb-on-search="searchCtrl.applySearchText(searchText)"> ' +
                 '</bb-search-input>';
-                
+
                 searchEl = initSearch(placeholderHtml);
 
                 inputEl = findSearchInput(searchEl);
@@ -468,7 +501,7 @@
                     'bb-search-placeholder="searchCtrl.placeholder" ' +
                     'bb-on-search="searchCtrl.applySearchText(searchText)"> ' +
                 '</bb-search-input>';
-                
+
                 searchEl = initSearch(placeholderHtml);
 
                 inputEl = findSearchInput(searchEl);
@@ -489,7 +522,7 @@
                 $scope.searchCtrl = {
 
                 };
-                
+
                 searchEl = initSearch(placeholderHtml);
 
                 inputEl = findSearchInput(searchEl);
@@ -518,7 +551,7 @@
                 $scope.searchCtrl = {
                     placeholder: 'Search'
                 };
-                
+
                 searchEl = initSearch(placeholderHtml);
 
                 inputEl = findSearchInput(searchEl);
@@ -533,7 +566,7 @@
                 var actualSearchText,
                 searchEl,
                 clearButtonEl;
-            
+
                 $scope.searchCtrl = {
                     applySearchText: function (searchText) {
                         actualSearchText = searchText;
@@ -561,7 +594,7 @@
                 var actualSearchText,
                 searchEl,
                 clearButtonEl;
-            
+
                 $scope.searchCtrl = {
                     applySearchText: function (searchText) {
                         actualSearchText = searchText;


### PR DESCRIPTION
Adding an attribute to the Search component that stops the responsive functionality if the flag is set to false upon creation. This keeps the textbox open at all times. If the attribute is not set, then nothing different should happen.

On the side, I don't know what happened with the lining, but not all those changes were made.