### PR TITLE
Bug 1104: Fixing Brazilian Phone Validation

### DIFF
--- a/js/sky/src/phonefield/docs/demo.md
+++ b/js/sky/src/phonefield/docs/demo.md
@@ -8,7 +8,7 @@ summary: The phone field directive creates a text box to format and validate int
 The phone field directive creates a text box for users to enter phone numbers. It wraps up the [intl-tel-input jQuery plugin](http://jackocnr.com/intl-tel-input.html) to format and validate international phone numbers. This plugin adds a dropdown for users to select a country and specifies the desired format and dial code. Users can also enter a dial code to select a country. You use the `bb-phone-field` directive in conjunction with the `ng-model` directive and bind the phone number value to `ng-model`.
 
 ### Dependencies ###
-- **[intl-tel-input](http://jackocnr.com/intl-tel-input.html) (8.5.2 or higher)** Enhances a text box to format and validate international phone numbers.
+- **[intl-tel-input](http://jackocnr.com/intl-tel-input.html) (13.0.0 or higher)** Enhances a text box to format and validate international phone numbers.
 
 ---
 

--- a/js/sky/src/phonefield/phonefield.directive.js
+++ b/js/sky/src/phonefield/phonefield.directive.js
@@ -34,7 +34,7 @@
                         // So, its dial code should just be 1 because the area code includes the dial code.
                         // Example countries: Bahamas, Cayman Islands, Barbados.
                         if (selectedCountryData.dialCode.toString()[0] === '1') {
-                            selectedCountryData.dialCode = 1;
+                            selectedCountryData.dialCode = '1';
                         }
 
                         return '+' + selectedCountryData.dialCode + ' ' + formattedNumber;

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "enquire.js": "git+https://github.com/WickyNilliams/enquire.js.git#v2.1.2",
     "fastclick": "1.0.6",
     "free-jqgrid": "git+https://github.com/blackbaud/jqGrid.git#v4.7.0",
-    "intl-tel-input": "8.5.2",
+    "intl-tel-input": "13.0.0",
     "jquery": "2.1.3",
     "jquery-ui-bundle": "1.11.4",
     "jquery-ui-touch-punch": "0.2.3",


### PR DESCRIPTION
Updating version of intl-tel-input.  There was a logical error in the directive where it was setting the phone number dial code to an integer instead of a string.  This had to be remedied to use the newer version of the library 