### PR TITLE
Support double-click to highlight keyinfo value/label individually

### DIFF
--- a/js/sky/templates/keyinfo/keyinfo.component.html
+++ b/js/sky/templates/keyinfo/keyinfo.component.html
@@ -1,4 +1,4 @@
 <div ng-class="{'bb-key-info-horizontal': $ctrl.bbKeyInfoLayout === 'horizontal'}" class="bb-key-info">
-    <div class="bb-key-info-value" ng-transclude="value"></div>
+    <div class="bb-key-info-value" ng-transclude="value"></div> 
     <div class="bb-key-info-label" ng-transclude="label"></div>
 </div>


### PR DESCRIPTION
`div` tags without a separating character (newline or space, for example) causes a "double-click" to highlight the first word of the second div. Add a space after the `bb-key-info-value` div to prevent the first word in the `bb-key-info-label` div from being highlighted on double-click. Likewise, this prevents the last word of the `bb-key-info-value` div from being highlighted upon double-click of the `bb-key-info-label` div.

This is re-produceable in latest version of Edge and Chrome on Windows 10. I have tested the fix in both browsers.

Alternative to a space after the `bb-key-info-value` would be a single newline between the two divs. That may be more readable to future maintainers.

I'll leave it up to maintainers as to which is preferred (space vs newline).