### PR TITLE
Update karma.conf-ci.js

### DIFF
--- a/config/karma/karma.conf-ci.js
+++ b/config/karma/karma.conf-ci.js
@@ -50,7 +50,7 @@ module.exports = function (config) {
             bs_osx_firefox_latest: {
                 base: base,
                 browser: 'firefox',
-                browser_version: '68.0 beta',          
+                browser_version: '78',          
                 os: 'OS X',
                 os_version: 'Yosemite'
             }


### PR DESCRIPTION
Builds are throwing the following error:
```
08 07 2020 15:55:59.387:ERROR [launcher.browserstack]: Can not start firefox 68.0 beta (OS X Yosemite)
  Error: Validation Failed - `browser_version` invalid
```

This will attempt to update the Firefox browser version. I pulled the latest supported version from here: https://www.browserstack.com/list-of-browsers-and-platforms/js_testing